### PR TITLE
Added alerts subelement for inputs and outputs

### DIFF
--- a/cpp.xsd
+++ b/cpp.xsd
@@ -547,6 +547,18 @@
 					</xsd:sequence>
 				</xsd:complexType>
 			</xsd:element>
+			<xsd:element name="alerts">
+				<xsd:complexType>
+					<xsd:sequence>
+						<xsd:element name="alert" maxOccurs="unbounded" type="xsd:string"
+							minOccurs="0">
+							<xsd:annotation>
+								<xsd:documentation xml:lang="en">Alert monitored (inputs) or raised (outputs) by the CPP.</xsd:documentation>
+							</xsd:annotation>
+						</xsd:element>
+					</xsd:sequence>
+				</xsd:complexType>
+			</xsd:element>
 		</xsd:sequence>
 	</xsd:complexType>
 	<xsd:complexType name="inputOutputElement">


### PR DESCRIPTION
In the CPP documentation for the inputs and outputs table, there are also alerts defined next to the data, metadata and guidance. This PR adds an alerts element with alert sub-element to the inputsOutputs type.