### PR TITLE
Added inputOutputElement type

### DIFF
--- a/cpp.xsd
+++ b/cpp.xsd
@@ -486,7 +486,8 @@
 			<xsd:element name="data">
 				<xsd:complexType>
 					<xsd:sequence>
-						<xsd:element name="dataElement" maxOccurs="unbounded" type="xsd:string"
+						<xsd:element name="dataElement" maxOccurs="unbounded"
+							type="inputOutputElement"
 							minOccurs="0">
 							<xsd:annotation>
 								<xsd:documentation xml:lang="en">Subtype of Object, or Information
@@ -499,7 +500,8 @@
 			<xsd:element name="metadata">
 				<xsd:complexType>
 					<xsd:sequence>
-						<xsd:element name="metadataElement" maxOccurs="unbounded" type="xsd:string"
+						<xsd:element name="metadataElement" maxOccurs="unbounded"
+							type="inputOutputElement"
 							minOccurs="0">
 							<xsd:annotation>
 								<xsd:documentation xml:lang="en">Subtype of Metadata that the CPP
@@ -512,7 +514,8 @@
 			<xsd:element name="guidance">
 				<xsd:complexType>
 					<xsd:sequence>
-						<xsd:element name="guidanceElement" maxOccurs="unbounded" type="xsd:string"
+						<xsd:element name="guidanceElement" maxOccurs="unbounded"
+							type="inputOutputElement"
 							minOccurs="0">
 							<xsd:annotation>
 								<xsd:documentation xml:lang="en">Guidance or documentation that the
@@ -524,6 +527,21 @@
 				</xsd:complexType>
 			</xsd:element>
 		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="inputOutputElement">
+		<xsd:annotation>
+			<xsd:documentation xml:lang="en">Input or output element</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:extension base="xsd:string">
+				<xsd:attribute name="optional" type="xsd:boolean" default="false">
+					<xsd:annotation>
+						<xsd:documentation xml:lang="en">States whether the element is optional, 
+							if applicable.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:extension>
+		</xsd:simpleContent>
 	</xsd:complexType>
 	<xsd:complexType name="institution">
 		<xsd:sequence>


### PR DESCRIPTION
A new type inputOutputElement type is introduced and replaces the xsd:string type of the sub-elements of inputs and outputs.

The new type adds an optional boolean attribute named 'optional' with default value 'false'. This is required because in some CPPs some input or output elements are marked as optional.