### PR TITLE
Version number updated for XML CPPs

### DIFF
--- a/CPP-001/cpp-001.xml
+++ b/CPP-001/cpp-001.xml
@@ -21,7 +21,7 @@
             <cpp:version>
                 <cpp:versionNumber>
                     <cpp:majorVersion>1</cpp:majorVersion>
-                    <cpp:minorVersion>0</cpp:minorVersion>
+                    <cpp:minorVersion>1</cpp:minorVersion>
                     <cpp:patchVersion>0</cpp:patchVersion>
                 </cpp:versionNumber>
                 <cpp:versionDate>2025-08-29</cpp:versionDate>

--- a/CPP-002/cpp-002.xml
+++ b/CPP-002/cpp-002.xml
@@ -17,7 +17,7 @@
             <cpp:version>
                 <cpp:versionNumber>
                     <cpp:majorVersion>1</cpp:majorVersion>
-                    <cpp:minorVersion>0</cpp:minorVersion>
+                    <cpp:minorVersion>1</cpp:minorVersion>
                     <cpp:patchVersion>0</cpp:patchVersion>
                 </cpp:versionNumber>
                 <cpp:versionDate>2025-08-29</cpp:versionDate>

--- a/CPP-003/cpp-003.xml
+++ b/CPP-003/cpp-003.xml
@@ -20,7 +20,7 @@
             <cpp:version>
                 <cpp:versionNumber>
                     <cpp:majorVersion>1</cpp:majorVersion>
-                    <cpp:minorVersion>0</cpp:minorVersion>
+                    <cpp:minorVersion>1</cpp:minorVersion>
                     <cpp:patchVersion>0</cpp:patchVersion>
                 </cpp:versionNumber>
                 <cpp:versionDate>2025-08-29</cpp:versionDate>

--- a/CPP-005/cpp_005.xml
+++ b/CPP-005/cpp_005.xml
@@ -21,7 +21,7 @@
             <cpp:version>
                 <cpp:versionNumber>
                     <cpp:majorVersion>1</cpp:majorVersion>
-                    <cpp:minorVersion>0</cpp:minorVersion>
+                    <cpp:minorVersion>1</cpp:minorVersion>
                     <cpp:patchVersion>0</cpp:patchVersion>
                 </cpp:versionNumber>
                 <cpp:versionDate>2025-08-29</cpp:versionDate>

--- a/CPP-007/cpp-007.xml
+++ b/CPP-007/cpp-007.xml
@@ -21,7 +21,7 @@
             <cpp:version>
                 <cpp:versionNumber>
                     <cpp:majorVersion>1</cpp:majorVersion>
-                    <cpp:minorVersion>0</cpp:minorVersion>
+                    <cpp:minorVersion>1</cpp:minorVersion>
                     <cpp:patchVersion>0</cpp:patchVersion>
                 </cpp:versionNumber>
                 <cpp:versionDate>2025-08-29</cpp:versionDate>

--- a/CPP-009/cpp-009.xml
+++ b/CPP-009/cpp-009.xml
@@ -20,7 +20,7 @@
             <cpp:version>
                 <cpp:versionNumber>
                     <cpp:majorVersion>1</cpp:majorVersion>
-                    <cpp:minorVersion>0</cpp:minorVersion>
+                    <cpp:minorVersion>1</cpp:minorVersion>
                     <cpp:patchVersion>0</cpp:patchVersion>
                 </cpp:versionNumber>
                 <cpp:versionDate>2025-08-29</cpp:versionDate>


### PR DESCRIPTION
All CPPs in XML are considered version 1.1 => minor version number updated.