### PR TITLE
Github action validate

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,10 +1,6 @@
+name: Validate CPP XML
+
 on:
-    push:
-        branches:
-            - dev
-        paths:
-            - 'CPP-*/cpp-*.xml'
-            - 'cpp.xsd'
     pull_request:
         branches:
             - dev
@@ -16,14 +12,35 @@ jobs:
     validate:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v3
+            - name: Checkout
+              uses: actions/checkout@v4
             
-            - name: Install xmllint
-              run: sudo apt-get install -y libxml2-utils
-            
-            - name: Validate XML files against schema
+            - name: Install xmllint (libxml2-utils)
+              run: sudo apt-get update && sudo apt-get install -y libxml2-utils
+
+            - name: Find XML files
+              id: find_files
               run: |
-                    for file in CPP-*/cpp-*.xml; do
-                        echo "Validating $file..."
-                        xmllint --schema cpp.xsd "$file" --noout
-                    done
+                files=$(git ls-files 'CPP-*/cpp-*.xml' || true)
+                if [ -z "$files" ]; then
+                    echo "no_files=true" >> $GITHUB_OUTPUT
+                    echo "No matching XML files found."
+                else
+                    echo "no_files=false" >> $GITHUB_OUTPUT
+                    echo "$files" > /tmp/xml_files
+                    cat /tmp/xml_files
+                fi
+
+            - name: Validate XML files against cpp.xsd
+              if: steps.find_files.outputs.no_files == 'false'
+              run: |
+                set -e
+                errors=0
+                for f in $(cat /tmp/xml_files); do
+                    echo "Validating $f against cpp.xsd"
+                    xmllint --noout --schema cpp.xsd "$f" || errors=$((errors+1))
+                done
+                if [ $errors -gt 0 ]; then
+                    echo "$errors file(s) failed validation"
+                    exit 1
+                fi


### PR DESCRIPTION
Added a Github action that validates all the cpp-xxx.xml files against the cpp.xsd. This happens only when a cpp-xxx.xml or the cpp.xsd schema is pushed to the dev branch directly or via a pull request.