### PR TITLE
Fixed many issues in the XML to HTML transformation

### DIFF
--- a/cpp2html.xsl
+++ b/cpp2html.xsl
@@ -313,25 +313,29 @@
 
             <h2>4. Reference implementations</h2>
 
-            <div class="usecases">
-
-                <h3>Use cases</h3>
-
-                <xsl:call-template name="useCases">
-                    <xsl:with-param name="data" select="cpp:referenceImplementations/cpp:useCases" />
-                </xsl:call-template>
-
-            </div>
-
-            <div class="documenation">
-
-                <h3>Publicly available documentation</h3>
-
-                <xsl:call-template name="publicDocumentationTable">
-                    <xsl:with-param name="data" select="cpp:referenceImplementations" />
-                </xsl:call-template>
-
-            </div>
+            <xsl:if test="count(cpp:referenceImplementations/cpp:useCases/cpp:useCase) &gt; 0">
+                <div class="usecases">
+                    
+                    <h3>Use cases</h3>
+                    
+                    <xsl:call-template name="useCases">
+                        <xsl:with-param name="data" select="cpp:referenceImplementations/cpp:useCases" />
+                    </xsl:call-template>
+                    
+                </div>
+            </xsl:if>
+                
+            <xsl:if test="count(cpp:referenceImplementations/cpp:publicDocumentation) &gt; 0">
+                <div class="documenation">
+                    
+                    <h3>Publicly available documentation</h3>
+                    
+                    <xsl:call-template name="publicDocumentationTable">
+                        <xsl:with-param name="data" select="cpp:referenceImplementations" />
+                    </xsl:call-template>
+                    
+                </div>
+            </xsl:if>
         </div>
 
     </xsl:template>
@@ -761,7 +765,7 @@
                     </xsl:choose>
                 </tr>
             </xsl:for-each>
-            
+
         </table>
 
     </xsl:template>


### PR DESCRIPTION
Changes:
- Added <br /> in the HTML output when multiple <span> elements are created
- Fixed layout of the steps table when inputs or outputs are not present (fixes #59)
- When multiple CPP identifiers are added, the expansions with labels are contatenated with ','
- Inputs and outputs table support for optional section (fixes #58)
- Adds required '/' entries in dependencies, certifications and frameworks table
- Hide Use case and/or Documentation headers if there are no use cases or documentation references
- Added alternative layout for steps table that is better suited for HTML output (implemented, but not yet activated)