### PR TITLE
Migrated CPP-013 to XML

### DIFF
--- a/CPP-013/cpp-013.xml
+++ b/CPP-013/cpp-013.xml
@@ -729,7 +729,7 @@
                     https://knowledge.exlibrisgroup.com/Rosetta/Knowledge_Articles/Is_there_a_list_of_all_of_the_SOLR_search_fields_in_Rosetta%3F
                 </cpp:hyperlink>
             </cpp:linkToDocumentation>
-            <cpp:linkToDocumentation xml:lang="e">
+            <cpp:linkToDocumentation xml:lang="en">
                 <cpp:hyperlink>
                     https://wiki.tib.eu/confluence/spaces/lza/pages/93608951/Metadata
                 </cpp:hyperlink>

--- a/CPP-013/cpp-013.xml
+++ b/CPP-013/cpp-013.xml
@@ -347,6 +347,11 @@
                     <span>Produce Report and deliver to Requestor.</span>
                     <span>If a report is produced regularly, then loop to Step 3a.</span>
                 </cpp:stepDescription>
+                <cpp:output>
+                    <cpp:outputElement>
+                        <span>Report</span>
+                    </cpp:outputElement>
+                </cpp:output>
             </cpp:step>
         </cpp:stepByStepDescription>
     </cpp:process>
@@ -464,7 +469,7 @@
             <cpp:relatedCPP>CPP-004</cpp:relatedCPP>
             <cpp:relationshipDescription>
                 <span>
-                    Fixing corrupted<em>AIPs</em> produces<em>Provenance metadata</em>
+                    Fixing corrupted <em>AIPs</em> produces <em>Provenance metadata</em>
                     and data for quality reporting to the stakeholders.
                 </span>
             </cpp:relationshipDescription>
@@ -592,7 +597,7 @@
             <cpp:relationshipDescription>
                 <span>
                     Enabling Access of contents include
-                    providing<em>Provenance metadata</em>,
+                    providing <em>Provenance metadata</em>,
                     statistical data and quality reports to
                     the consumer.
                 </span>
@@ -745,7 +750,7 @@
         <cpp:publicDocumentation>
             <cpp:institution>
                 <cpp:institutionLabel>Archivematica</cpp:institutionLabel>
-                <cpp:institutionCountry>US</cpp:institutionCountry>
+                <cpp:institutionCountry>CA</cpp:institutionCountry>
                 <cpp:institutionType>Digital preservation system</cpp:institutionType>
             </cpp:institution>
             <cpp:linkToDocumentation xml:lang="en">

--- a/CPP-013/cpp-013.xml
+++ b/CPP-013/cpp-013.xml
@@ -1,0 +1,781 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<cpp:cpp xmlns:cpp="https://eden-fidelis.eu/cpp/cpp/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.w3.org/1999/xhtml" xsi:schemaLocation="https://eden-fidelis.eu/cpp/cpp/ ../cpp.xsd" ID="CPP-013" xml:lang="en">
+    <cpp:header>
+        <cpp:label>Object Management Reporting</cpp:label>
+        <cpp:authors>
+            <cpp:author>Johan Kylander</cpp:author>
+        </cpp:authors>
+        <cpp:contributors>
+            <cpp:contributor>Matthew Addis</cpp:contributor>
+        </cpp:contributors>
+        <cpp:evaluators>
+            <cpp:evaluator>Franziska Schwab</cpp:evaluator>
+            <cpp:evaluator>Felix Burger</cpp:evaluator>
+            <cpp:evaluator>Maria Benauer</cpp:evaluator>
+        </cpp:evaluators>
+        <cpp:history>
+            <cpp:version>
+                <cpp:versionNumber>
+                    <cpp:majorVersion>1</cpp:majorVersion>
+                    <cpp:minorVersion>0</cpp:minorVersion>
+                    <cpp:patchVersion>0</cpp:patchVersion>
+                </cpp:versionNumber>
+                <cpp:versionDate>2025-08-29</cpp:versionDate>
+                <cpp:versionNotes>Milestone version</cpp:versionNotes>
+            </cpp:version>
+            <cpp:version>
+                <cpp:versionNumber>
+                    <cpp:majorVersion>1</cpp:majorVersion>
+                    <cpp:minorVersion>1</cpp:minorVersion>
+                    <cpp:patchVersion>0</cpp:patchVersion>
+                </cpp:versionNumber>
+                <cpp:versionDate>2026-03-26</cpp:versionDate>
+                <cpp:versionNotes>Migration to XML</cpp:versionNotes>
+            </cpp:version>
+        </cpp:history>
+    </cpp:header>
+    <cpp:shortDefinition>
+        The TDA delivers reporting to enable the effective management of Objects. This must include
+        a wide range of functional, operational, and statistical reports and analytics.
+    </cpp:shortDefinition>
+    <cpp:classification>
+        <cpp:oaisClassification>Administration</cpp:oaisClassification>
+        <cpp:logicalClassification>Preservation Planning</cpp:logicalClassification>
+    </cpp:classification>
+    <cpp:descriptionAndScope>
+        <p>
+            Object management reporting is a process in which the TDA creates reports; outputs
+            <em>Provenance metadata</em>; and produces statistical data on the content it preserves. The
+            reporting is needed to enable effective management of <em>Objects</em>. Reporting is done for both
+            the TDA itself, helping it in its preservation planning and as input for <b>Risk Mitigation</b>
+            (CPP-012), and for the designated communities and stakeholders that produce and
+            consume the data. Effective reporting enables a TDA to conduct digital preservation and to
+            select the <em>Information packages</em> or <em>Objects</em> when performing preservation actions.
+        </p>
+        <p>
+            Reporting on the content includes reports and <em>Provenance metadata</em> from other CPPs that
+            perform actions on digital content. For example, this includes processes that periodically
+            check the quality of the data in <b>Data Quality Assessment</b> (CPP-019) or during triggered
+            events such as <b>Ingest</b> (CPP-029) and <b>Enabling Access</b> (CPP-025):
+        </p>
+        <ul>
+            <li>Reports from periodic <b>Integrity Checking</b> (CPP-003);</li>
+            <li>Preservation actions taken and documented in <b>Data Corruption Management</b> (CPP-004);</li>
+            <li><b>Virus Scanning</b> reports (CPP-007);</li>
+            <li><b>File Format Identification</b> (CPP-008) reports;</li>
+            <li><b>File Format Validation</b> (CPP-010) reports;</li>
+            <li><b>File Migration</b> (CPP-014);</li>
+            <li>Data on <b>Emulation and Rendering Tools</b> (CPP-015);</li>
+            <li><em>Metadata</em> from <b>Metadata Ingest and Management</b> (CPP-016);</li>
+            <li><em>Metadata</em> from <b>Rights Management</b> (CPP-020);</li>
+            <li><em>Metadata</em> from <b>Significant Properties Definition</b> (CPP-022);</li>
+            <li>Preservation actions taken and documented in <b>File Repair</b> (CPP-027);</li>
+            <li>Data from the <b>Creation of Derivatives</b> (CPP-028) process;</li>
+            <li><em>Metadata</em> from the access and use of <em>Objects</em> in TDA by the designated community;</li>
+            <li><em>Metadata</em> on the data volumes and growth rates of the <em>Objects</em> held by the TDA.</li>
+        </ul>
+        <p>
+            As the purpose of reporting is to enable the preservation and the management of digital
+            <em>Objects</em>, the reports usually cover the main types of data that a TDA operates with. This may
+            include data on:
+        </p>
+        <ul>
+            <li>File formats;</li>
+            <li><em>Technical metadata</em> and significant properties of <em>Objects</em>;</li>
+            <li>Tools and software needed to manage the content;</li>
+            <li>The health of <em>Objects</em> and actions taken to remedy errors;</li>
+            <li>The hardware infrastructure;</li>
+            <li><em>Metadata</em> and metadata standards;</li>
+            <li>The provenance of the <em>Objects</em>;</li>
+            <li>The licenses and rights to retain, preserve and provide access to <em>Objects</em>;</li>
+            <li>The level of usage of <em>Objects</em> in the TDA;</li>
+        </ul>
+        <p>
+            The report types produced in the reporting process can be categorised as follows:
+        </p>
+        <ul>
+            <li><em>Statistical data</em> (e.g. number of <em>Objects</em>, file sizes etc.): Used for helping a TDA or
+                stakeholder assess the scope of preservation actions;</li>
+            <li><em>Provenance metadata</em> (i.e. documented preservation actions by the TDA): Used for
+                assessing the state of <em>Objects</em>, the so called "health" of the <em>Files</em>, and to add
+                authenticity by documenting the life-cycle of all digital content in a TDA;</li>
+            <li><em>In depth machine-actionable reports</em> (usually produced by tools): These are used as
+                input in other processes conducted by the TDA;</li>
+            <li><em>Links to knowledge base resources</em> (e.g. file format registries): These are used to
+                help a TDA in preservation planning.</li>
+        </ul>
+        <p>
+            Reporting activities as well as the report types listed above feed into a wide range of
+            management processes and decision making. Some examples include:
+        </p>
+        <ul>
+            <li>Risk assessment and preservation planning (e.g. using reports on file formats);</li>
+            <li>Reporting to funders and stakeholders (e.g. by providing usage statistics);</li>
+            <li>Capacity planning and purchasing decisions (e.g. purchasing and refreshment of
+                storage infrastructure based on statistics on data volumes and growth rates);</li>
+            <li>Compliance assessments (e.g. using reports on rights and participant consent to
+                check that personal data is retained in compliance with GDPR);</li>
+            <li>Optimisation and cost management (e.g. identification of expensive or inefficient
+                processes based on execution time and steps required, or optimising the use of
+                different storage classes for frequently or infrequently accessed data based on usage
+                statistics);</li>
+            <li>Identification of anomalies in error rates or failures (e.g. unusually problematic
+                content from specific depositors);</li>
+            <li>Deaccessioning of <em>Objects</em> (e.g. reports on <em>Objects</em> that no longer need to be
+                retained because their retention schedules are about to expire, or reports on quality
+                assessment that mean <em>Objects</em> no longer meet the needs of a designated 
+                community);</li>
+            <li>Environmental sustainability (e.g. use of storage, processing and access statistics as
+                an input to calculating carbon footprint).</li>
+        </ul>
+        <p>
+            When the process description uses the term <em>report</em>, it can be any of the above.
+        </p>
+    </cpp:descriptionAndScope>
+    <cpp:process>
+        <cpp:inputs>
+            <cpp:metadata>
+                <cpp:metadataElement>Provenance metadata</cpp:metadataElement>
+                <cpp:metadataElement>Technical metadata</cpp:metadataElement>
+                <cpp:metadataElement>Rights data</cpp:metadataElement>
+                <cpp:metadataElement>Errors and Warnings</cpp:metadataElement>
+            </cpp:metadata>
+        </cpp:inputs>
+        <cpp:outputs>
+            <cpp:metadata>
+                <cpp:metadataElement>Provenance metadata</cpp:metadataElement>
+            </cpp:metadata>
+            <cpp:guidance>
+                <cpp:guidanceElement>Reports</cpp:guidanceElement>
+                <cpp:guidanceElement>Statistical data</cpp:guidanceElement>
+            </cpp:guidance>
+        </cpp:outputs>
+        <cpp:triggerEvents>
+            <cpp:triggerEvent>
+                <cpp:description><span>Ingest</span></cpp:description>
+                <cpp:correspondingCPP>CPP-029</cpp:correspondingCPP>
+            </cpp:triggerEvent>
+            <cpp:triggerEvent>
+                <cpp:description><span>Enabling Access</span></cpp:description>
+                <cpp:correspondingCPP>CPP-025</cpp:correspondingCPP>
+            </cpp:triggerEvent>
+            <cpp:triggerEvent>
+                <cpp:description><span>Risk Mitigation</span></cpp:description>
+                <cpp:correspondingCPP>CPP-012</cpp:correspondingCPP>
+            </cpp:triggerEvent>
+            <cpp:triggerEvent>
+                <cpp:description><span>Data Quality Assessment</span></cpp:description>
+                <cpp:correspondingCPP>CPP-019</cpp:correspondingCPP>
+            </cpp:triggerEvent>
+            <cpp:triggerEvent>
+                <cpp:description><span>Reporting needs from the stakeholders or designated communities</span></cpp:description>
+            </cpp:triggerEvent>
+        </cpp:triggerEvents>
+        <cpp:stepByStepDescription>
+            <cpp:step stepNumber="1a">
+                <cpp:input>
+                    <cpp:inputElement>
+                        <span>
+                            Reporting request (from CPPs, stakeholders or the consumers) in the form of a Report Specification
+                        </span>
+                    </cpp:inputElement>
+                    <cpp:supplier>CPP-029</cpp:supplier>
+                    <cpp:supplier>CPP-025</cpp:supplier>
+                    <cpp:supplier>CPP-012</cpp:supplier>
+                    <cpp:supplier>CPP-019</cpp:supplier>
+                </cpp:input>
+                <cpp:stepDescription>
+                    <span>
+                        The TDA receives the request and determines what data is required to provide the requested report
+                    </span>
+                </cpp:stepDescription>
+                <cpp:output>
+                    <cpp:outputElement>
+                        <span>
+                            Specification of the data required for the report
+                        </span>
+                    </cpp:outputElement>
+                </cpp:output>
+            </cpp:step>
+            <cpp:step stepNumber="1b">
+                <cpp:input>
+                    <cpp:inputElement>
+                        <span>Specification of the data required for the report</span>
+                    </cpp:inputElement>
+                </cpp:input>
+                <cpp:stepDescription>
+                    <span>
+                        Determine if reporting data is available 
+                        (e.g. is it already an output of other CPPs)
+                    </span>
+                </cpp:stepDescription>
+                <cpp:output>
+                    <cpp:outputElement>
+                        <span>Availability of data required for the report</span>
+                    </cpp:outputElement>
+                </cpp:output>
+            </cpp:step>
+            <cpp:step stepNumber="1c">
+                <cpp:input>
+                    <cpp:inputElement>
+                        <span>
+                            Availability of data required for the report.
+                        </span>
+                    </cpp:inputElement>
+                </cpp:input>
+                <cpp:stepDescription>
+                    <span>
+                        If the reporting data is not available:
+                    </span>
+                    <ol>
+                        <li>Determine the steps that would be needed in order to capture it</li>
+                        <li>Discuss reporting requirements with the requestor and agree revisions to report</li>
+                    </ol>
+                </cpp:stepDescription>
+                <cpp:output>
+                    <cpp:outputElement>
+                        <span>
+                            Modifications to (i) Report Specification and 
+                            (ii) Specification of data required for the report
+                        </span>
+                    </cpp:outputElement>
+                </cpp:output>
+            </cpp:step>
+            <cpp:step stepNumber="2a">
+                <cpp:input>
+                    <cpp:inputElement>
+                        <span>
+                            Specification of data required for the report (from 1a or 1c)
+                        </span>
+                    </cpp:inputElement>
+                </cpp:input>
+                <cpp:stepDescription>
+                    <span>
+                        If needed, CPPs that produce the required data are revised so that the necessary 
+                        data is produced and compiles the report (as provided by other CPPs)
+                    </span>
+                    <span>
+                        The TDA gathers and aggregates the data needed for the report.
+                    </span>
+                </cpp:stepDescription>
+                <cpp:output>
+                    <cpp:outputElement>
+                        <span>
+                            Data required for report
+                        </span>
+                    </cpp:outputElement>
+                </cpp:output>
+            </cpp:step>
+            <cpp:step stepNumber="2b">
+                <cpp:input>
+                    <cpp:inputElement>
+                        <span>Data required for report</span>
+                    </cpp:inputElement>
+                </cpp:input>
+                <cpp:input>
+                    <cpp:inputElement>
+                        <span>Report Specification</span>
+                    </cpp:inputElement>
+                </cpp:input>
+                <cpp:stepDescription>
+                    <span>
+                        The report is compiled and reviewed with the requestor..
+                    </span>
+                    <span>
+                        If further modifications are needed to the data 
+                        and data collection, then go to step 2a.
+                    </span>
+                </cpp:stepDescription>
+                <cpp:output>
+                    <cpp:outputElement>
+                        <span>
+                            Finalised Specification of Report
+                        </span>
+                    </cpp:outputElement>
+                </cpp:output>
+            </cpp:step>
+            <cpp:step stepNumber="3a">
+                <cpp:input>
+                    <cpp:inputElement>
+                        <span>Reporting schedule</span>
+                    </cpp:inputElement>
+                </cpp:input>
+                <cpp:stepDescription>
+                    <span>
+                        If the report is required on a regular basis, 
+                        e.g. monthly,   then a reporting schedule is set 
+                        and data is collected on a regular basis
+                    </span>
+                </cpp:stepDescription>
+                <cpp:output>
+                    <cpp:outputElement>
+                        <span>Data required for report</span>
+                    </cpp:outputElement>
+                    <cpp:customer>CPP-029</cpp:customer>
+                    <cpp:customer>CPP-025</cpp:customer>
+                    <cpp:customer>CPP-012</cpp:customer>
+                    <cpp:customer>CPP-019</cpp:customer>
+                </cpp:output>
+            </cpp:step>
+            <cpp:step stepNumber="3b">
+                <cpp:input>
+                    <cpp:inputElement>
+                        <span>Data required for report (from 3a)</span>
+                    </cpp:inputElement>
+                </cpp:input>
+                <cpp:stepDescription>
+                    <span>Gather and aggregate data for report</span>
+                </cpp:stepDescription>
+                <cpp:output>
+                    <cpp:outputElement>
+                        <span>Data for report.</span>
+                    </cpp:outputElement>
+                </cpp:output>
+            </cpp:step>
+            <cpp:step stepNumber="3c">
+                <cpp:input>
+                    <cpp:inputElement>
+                        <span>Data for report (from 3b)</span>
+                    </cpp:inputElement>
+                </cpp:input>
+                <cpp:input>
+                    <cpp:inputElement>
+                        <span>Finalised Report Specification (from 2b)</span>
+                    </cpp:inputElement>
+                </cpp:input>
+                <cpp:stepDescription>
+                    <span>Produce Report and deliver to Requestor.</span>
+                    <span>If a report is produced regularly, then loop to Step 3a.</span>
+                </cpp:stepDescription>
+            </cpp:step>
+        </cpp:stepByStepDescription>
+    </cpp:process>
+    <cpp:rationaleWorstCase>
+        <cpp:purpose>
+            <cpp:purposeDescription>
+                <span>
+                    The TDA knows what <em>Information packages</em> it preserves 
+                    and what they contain
+                </span>
+            </cpp:purposeDescription>
+            <cpp:worstCase>
+                <span>
+                    Without being able to locate and report the data it holds, the 
+                    TDA cannot perform any preservation actions or provide (e.g. 
+                    searching by <em>Rights</em>, <em>Provenance</em> and 
+                    <em>Descriptive metadata</em> within the <em>Information packages</em>).
+                </span>
+            </cpp:worstCase>
+        </cpp:purpose>
+        <cpp:purpose>
+            <cpp:purposeDescription>
+                <span>
+                    The TDA knows which file formats it holds and can locate these
+                    <em>Objects</em> within <em>Information packages</em>
+                </span>
+            </cpp:purposeDescription>
+            <cpp:worstCase>
+                <span>
+                    Without knowing in what format the <em>Objects</em> it holds are, 
+                    the TDA cannot plan preservation actions or inform the designated 
+                    communities about preservation strategies.
+                </span>
+            </cpp:worstCase>
+        </cpp:purpose>
+        <cpp:purpose>
+            <cpp:purposeDescription>
+                <span>
+                    The TDA knows what metadata standards it holds and which 
+                    standards apply to which <em>Objects</em>
+                </span>
+            </cpp:purposeDescription>
+            <cpp:worstCase>
+                <span>
+                    Without being able to analyse the <em>Objects</em> and their 
+                    significant properties, the TDA cannot plan preservation actions, 
+                    provide discovery or access.
+                </span>
+            </cpp:worstCase>
+        </cpp:purpose>
+        <cpp:purpose>
+            <cpp:purposeDescription>
+                <span>
+                    The TDA maintains and generates <em>Provenance metadata</em> 
+                    during preservation
+                </span>
+            </cpp:purposeDescription>
+            <cpp:worstCase>
+                <span>
+                    Processes that produce reports and <em>provenance data</em> must 
+                    have their output stored. This information is needed to analyse 
+                    the <em>Objects</em> in a TDA, create quality reports, provide 
+                    designated communities with assurance of a high quality digital 
+                    preservation
+                </span>
+            </cpp:worstCase>
+        </cpp:purpose>
+        <cpp:purpose>
+            <cpp:purposeDescription>
+                <span>
+                    The TDA knows its hardware infrastructure and 
+                    has a plan for its management
+                </span>
+            </cpp:purposeDescription>
+            <cpp:worstCase>
+                <span>
+                    Without knowledge on the hardware infrastructure, the TDA 
+                    cannot maintain high-quality bit-level preservation and 
+                    report to the stakeholders.
+                </span>
+            </cpp:worstCase>
+        </cpp:purpose>
+        <cpp:purpose>
+            <cpp:purposeDescription>
+                <span>
+                    The TDA knows the rights it has to preserve and
+                    provide access to its holdings.
+                </span>
+            </cpp:purposeDescription>
+            <cpp:worstCase>
+                <span>
+                    Without knowledge of rights and
+                    retention schedules, the TDA cannot
+                    know with confidence that it has the
+                    permission to preserve its holdings or
+                    whether it is holding content that should
+                    be deaccessioned.
+                </span>
+            </cpp:worstCase>
+        </cpp:purpose>
+    </cpp:rationaleWorstCase>
+    <cpp:cppRelationships>
+        <cpp:relationship>
+            <cpp:relationshipType>Requires</cpp:relationshipType>
+            <cpp:relatedCPP>CPP-003</cpp:relatedCPP>
+            <cpp:relationshipDescription>
+                <span>
+                    Periodic integrity checking provides reports on the
+                    integrity of data and reports corrupted <em>AIPs</em>.
+                </span>
+            </cpp:relationshipDescription>
+        </cpp:relationship>
+        <cpp:relationship>
+            <cpp:relationshipType>Requires</cpp:relationshipType>
+            <cpp:relatedCPP>CPP-004</cpp:relatedCPP>
+            <cpp:relationshipDescription>
+                <span>
+                    Fixing corrupted<em>AIPs</em> produces<em>Provenance metadata</em>
+                    and data for quality reporting to the stakeholders.
+                </span>
+            </cpp:relationshipDescription>
+        </cpp:relationship>
+        <cpp:relationship>
+            <cpp:relationshipType>Requires</cpp:relationshipType>
+            <cpp:relatedCPP>CPP-005</cpp:relatedCPP>
+            <cpp:relationshipDescription>
+                <span>
+                    Soft dependency (i.e. may require): The management and
+                    reporting should require that the data is identified with
+                    PIDs.
+                </span>
+            </cpp:relationshipDescription>
+        </cpp:relationship>
+        <cpp:relationship>
+            <cpp:relationshipType>Requires</cpp:relationshipType>
+            <cpp:relatedCPP>CPP-007</cpp:relatedCPP>
+            <cpp:relationshipDescription>
+                <span>
+                    Reports on virus scanning activities, frequency of threats,
+                    and outcomes of the actions provide essential input for
+                    operational management and risk assessment.
+                </span>
+            </cpp:relationshipDescription>
+        </cpp:relationship>
+        <cpp:relationship>
+            <cpp:relationshipType>Requires</cpp:relationshipType>
+            <cpp:relatedCPP>CPP-008</cpp:relatedCPP>
+            <cpp:relationshipDescription>
+                <span>
+                    File format identification reports are required for a TDA to
+                    enable it to manage its content.
+                </span>
+            </cpp:relationshipDescription>
+        </cpp:relationship>
+        <cpp:relationship>
+            <cpp:relationshipType>Requires</cpp:relationshipType>
+            <cpp:relatedCPP>CPP-010</cpp:relatedCPP>
+            <cpp:relationshipDescription>
+                <span>
+                    File format validation provide essential information on the
+                    well-formedness and validity of the <em>Objects</em>; validation
+                    errors; and data on the tools used in the process.
+                </span>
+            </cpp:relationshipDescription>
+        </cpp:relationship>
+        <cpp:relationship>
+            <cpp:relationshipType>Requires</cpp:relationshipType>
+            <cpp:relatedCPP>CPP-014</cpp:relatedCPP>
+            <cpp:relationshipDescription>
+                <span>
+                    File migration provides information on the outcome of the
+                    process as well as tools used.
+                </span>
+            </cpp:relationshipDescription>
+        </cpp:relationship>
+        <cpp:relationship>
+            <cpp:relationshipType>Requires</cpp:relationshipType>
+            <cpp:relatedCPP>CPP-015</cpp:relatedCPP>
+            <cpp:relationshipDescription>
+                <span>
+                    The process of selecting tools for emulation and rendering
+                    provides data to the TDA for reporting to the designated
+                    communities.
+                </span>
+            </cpp:relationshipDescription>
+        </cpp:relationship>
+        <cpp:relationship>
+            <cpp:relationshipType>Requires</cpp:relationshipType>
+            <cpp:relatedCPP>CPP-016</cpp:relatedCPP>
+            <cpp:relationshipDescription>
+                <span>
+                    Metadata ingest provides new <em>Provenance metadata</em>.
+                </span>
+            </cpp:relationshipDescription>
+        </cpp:relationship>
+        <cpp:relationship>
+            <cpp:relationshipType>Requires</cpp:relationshipType>
+            <cpp:relatedCPP>CPP-022</cpp:relatedCPP>
+            <cpp:relationshipDescription>
+                <span>
+                    To report on the characteristics of <em>Objects</em> for deeper
+                    analysis, the significant properties must have been
+                    defined.
+                </span>
+            </cpp:relationshipDescription>
+        </cpp:relationship>
+        <cpp:relationship>
+            <cpp:relationshipType>Requires</cpp:relationshipType>
+            <cpp:relatedCPP>CPP-027</cpp:relatedCPP>
+            <cpp:relationshipDescription>
+                <span>
+                    Fixing invalid <em>Files</em> produces <em>Provenance metadata</em> and
+                    data for quality reporting to the stakeholders.
+                </span>
+            </cpp:relationshipDescription>
+        </cpp:relationship>
+        <cpp:relationship>
+            <cpp:relationshipType>Requires</cpp:relationshipType>
+            <cpp:relatedCPP>CPP-028</cpp:relatedCPP>
+            <cpp:relationshipDescription>
+                <span>
+                    Creation of new <em>Objects</em> provides data for statistical
+                    reporting.
+                </span>
+            </cpp:relationshipDescription>
+        </cpp:relationship>
+        <cpp:relationship>
+            <cpp:relationshipType>Affinity with</cpp:relationshipType>
+            <cpp:relatedCPP>CPP-029</cpp:relatedCPP>
+            <cpp:relationshipDescription>
+                <span>
+                    Ingest is both an important provider of
+                    reporting data to the TDA (via other
+                    CPPs) as well as a customer, as the
+                    ingest checks and outcomes must be
+                    reported to the producer.
+                </span>
+            </cpp:relationshipDescription>
+        </cpp:relationship>
+        <cpp:relationship>
+            <cpp:relationshipType>Affinity with</cpp:relationshipType>
+            <cpp:relatedCPP>CPP-025</cpp:relatedCPP>
+            <cpp:relationshipDescription>
+                <span>
+                    Enabling Access of contents include
+                    providing<em>Provenance metadata</em>,
+                    statistical data and quality reports to
+                    the consumer.
+                </span>
+            </cpp:relationshipDescription>
+        </cpp:relationship>
+        <cpp:relationship>
+            <cpp:relationshipType>Affinity with</cpp:relationshipType>
+            <cpp:relatedCPP>CPP-012</cpp:relatedCPP>
+            <cpp:relationshipDescription>
+                <span>
+                    To plan and mitigate risks in
+                    preservation, a TDA needs to provide
+                    input on the preservation system, the
+                    quality of the data, significant
+                    properties in <em>Objects</em>, storage
+                    management <em>Metadata</em> etc.
+                </span>
+            </cpp:relationshipDescription>
+        </cpp:relationship>
+        <cpp:relationship>
+            <cpp:relationshipType>Affinity with</cpp:relationshipType>
+            <cpp:relatedCPP>CPP-019</cpp:relatedCPP>
+            <cpp:relationshipDescription>
+                <span>
+                    To evaluate the quality of the data, the
+                    process needs input in the form of
+                    various <em>Metadata</em>.
+                </span>
+            </cpp:relationshipDescription>
+        </cpp:relationship>
+    </cpp:cppRelationships>
+    <cpp:frameworkMappings>
+        <cpp:mapping>
+            <cpp:frameworkName>CoreTrustSeal</cpp:frameworkName>
+            <cpp:correspondingSection>
+                <span>
+                    Reporting is not defined directly as a
+                    requirement, but as the category “Digital
+                    Object Management”, which contains the
+                    following requirements:
+                </span>
+                <ul>
+                    <li>Provenance and authenticity (R07)</li>
+                    <li>Deposit &amp; Appraisal (R08)</li>
+                    <li>Preservation plan (R09)</li>
+                    <li>Quality Assurance (R10)</li>
+                    <li>Workflows (R11)</li>
+                    <li>Discovery and Identification (R12)</li>
+                    <li>Reuse (R13)</li>
+                </ul>
+            </cpp:correspondingSection>
+        </cpp:mapping>
+        <cpp:mapping>
+            <cpp:frameworkName>Nestor Seal</cpp:frameworkName>
+            <cpp:correspondingSection>
+                <span>
+                    Reporting is not defined directly as a
+                    requirement, but there are specific
+                    requirements for various metadata
+                    categories, which are specified with
+                    reporting in mind:
+                </span>
+                <ul>
+                    <li>C27 Identification</li>
+                    <li>C28 Descriptive metadata</li>
+                    <li>C29 Structural metadata</li>
+                    <li>C30 Technical metadata</li>
+                    <li>C31 Logging the preservation measures</li>
+                    <li>C32 Administrative metadata</li>
+                </ul>
+            </cpp:correspondingSection>
+        </cpp:mapping>
+        <cpp:mapping>
+            <cpp:frameworkName>ISO 16363</cpp:frameworkName>
+            <cpp:correspondingSection>
+                <span>
+                    Reporting as such is not described, but
+                    referenced multiple times as a way for
+                    the TDA to demonstrate that it is meeting
+                    a requirement. See 3.2.1.3, 3.3.4, 3.5.1,
+                    4.1.7, 4.6.2.1, 5.1.1.1, 5.1.1.3 and
+                    5.1.1.3.1
+                </span>
+            </cpp:correspondingSection>
+        </cpp:mapping>
+        <cpp:mapping>
+            <cpp:frameworkName>OAIS</cpp:frameworkName>
+            <cpp:correspondingTerm>
+                <span>Generate Report</span>
+            </cpp:correspondingTerm>
+            <cpp:correspondingSection>
+                <span>4.2.3.5</span>
+            </cpp:correspondingSection>
+        </cpp:mapping>
+        <cpp:mapping>
+            <cpp:frameworkName>PREMIS</cpp:frameworkName>
+            <cpp:correspondingSection>
+                <span>
+                    PREMIS does not dedicate any
+                    documentation to reporting, but it
+                    mentions reporting when highlighting the
+                    importance of storing events and
+                    metadata.
+                </span>
+            </cpp:correspondingSection>
+        </cpp:mapping>
+    </cpp:frameworkMappings>
+    <cpp:referenceImplementations>
+        <cpp:publicDocumentation>
+            <cpp:institution>
+                <cpp:institutionLabel>
+                    TIB - Leibniz Information Centre
+                    for Science and Technology and
+                    University Library
+                </cpp:institutionLabel>
+                <cpp:institutionCountry>DE</cpp:institutionCountry>
+                <cpp:institutionType>National library</cpp:institutionType>
+                <cpp:institutionType>Non-commercial digital preservation service</cpp:institutionType>
+                <cpp:institutionType>Research infrastructure</cpp:institutionType>
+                <cpp:institutionType>Research performing organisation</cpp:institutionType>
+            </cpp:institution>
+            <cpp:linkToDocumentation xml:lang="en">
+                <cpp:hyperlink>
+                    https://knowledge.exlibrisgroup.com/Rosetta/Training/Rosetta_Essentials/Data_Management/7.1_Searching_the_Rosetta_Permanent_Repository
+                </cpp:hyperlink>                
+            </cpp:linkToDocumentation>
+            <cpp:linkToDocumentation xml:lang="en">
+                <cpp:hyperlink>
+                    https://knowledge.exlibrisgroup.com/Rosetta/Knowledge_Articles/Is_there_a_list_of_all_of_the_SOLR_search_fields_in_Rosetta%3F
+                </cpp:hyperlink>
+            </cpp:linkToDocumentation>
+            <cpp:linkToDocumentation xml:lang="e">
+                <cpp:hyperlink>
+                    https://wiki.tib.eu/confluence/spaces/lza/pages/93608951/Metadata
+                </cpp:hyperlink>
+            </cpp:linkToDocumentation>
+        </cpp:publicDocumentation>
+        <cpp:publicDocumentation>
+            <cpp:institution>
+                <cpp:institutionLabel>CSC - IT Center for Science Ltd.</cpp:institutionLabel>
+                <cpp:institutionCountry>FI</cpp:institutionCountry>
+                <cpp:institutionType>Non-commercial digital preservation service</cpp:institutionType>
+            </cpp:institution>
+            <cpp:linkToDocumentation xml:lang="en">
+                <cpp:hyperlink>
+                    https://digitalpreservation.fi/en/services/quality_reports/2024
+                </cpp:hyperlink>
+            </cpp:linkToDocumentation>
+        </cpp:publicDocumentation>
+        <cpp:publicDocumentation>
+            <cpp:institution>
+                <cpp:institutionLabel>Archivematica</cpp:institutionLabel>
+                <cpp:institutionCountry>US</cpp:institutionCountry>
+                <cpp:institutionType>Digital preservation system</cpp:institutionType>
+            </cpp:institution>
+            <cpp:linkToDocumentation xml:lang="en">
+                <cpp:hyperlink>
+                    https://www.archivematica.org/en/docs/archivematica-1.18
+                </cpp:hyperlink>
+                <cpp:comment>
+                    Limited reporting. However, Archivematica is built on
+                    MySQL and ElasticSearch so there is the potential to
+                    generate more reports by directly accessing the
+                    databases/indexes.
+                </cpp:comment>
+            </cpp:linkToDocumentation>
+        </cpp:publicDocumentation>
+        <cpp:publicDocumentation>
+            <cpp:institution>
+                <cpp:institutionLabel>Rosetta</cpp:institutionLabel>
+                <cpp:institutionCountry>UK</cpp:institutionCountry>
+                <cpp:institutionType>Digital preservation system</cpp:institutionType>
+            </cpp:institution>
+            <cpp:linkToDocumentation xml:lang="en">
+                <cpp:hyperlink>
+                    https://knowledge.exlibrisgroup.com/Rosetta/Training/Rosetta_Essentials/Data_Management/7.1_Searching_the_Rosetta_Permanent_Repository
+                </cpp:hyperlink>
+            </cpp:linkToDocumentation>
+            <cpp:linkToDocumentation xml:lang="en">
+                <cpp:hyperlink>
+                    https://knowledge.exlibrisgroup.com/Rosetta/Knowledge_Articles/Is_there_a_list_of_all_of_the_SOLR_search_fields_in_Rosetta%3F
+                </cpp:hyperlink>
+            </cpp:linkToDocumentation>
+        </cpp:publicDocumentation>
+    </cpp:referenceImplementations>
+</cpp:cpp> 


### PR DESCRIPTION
Fixes #76

Issues during migration:

- In the PDF the step-by-step description groups the steps into stages. There is no place to document that in the XML, so it was skipped
- Step 1a/Supplier: text was converted into separate CPP entries. List may not be complete
- Reference implementations: institution country is a required field, so added US for Archivematica and UK for Rosetta.
- Reference implementations: hyperlink is required, so added link to current release documentation for Archivematica.