### PR TITLE
Reviewed and a bit fixed stepGroups (from feature-branch: evolution/add-step-grouping-mikkol)

### DIFF
--- a/CPP-017/cpp-017.xml
+++ b/CPP-017/cpp-017.xml
@@ -227,169 +227,169 @@
         <cpp:stepByStepDescription>
             <cpp:stepGroup type="sequence">
                 <cpp:stepGroup type="alternative" label="Alternative triggers">
-            <cpp:step stepNumber="1a">
-                <cpp:input>
-                    <cpp:inputElement>
-                        <span>
-                            Quality reports 
-                        </span>
-                    </cpp:inputElement>
-                    <cpp:supplier>CPP-004</cpp:supplier>
-                    <cpp:supplier>CPP-027</cpp:supplier>
-                </cpp:input>
-                <cpp:stepDescription>
-                    <span>
-                        TDA finds out, from management events or other triggering events,
-                        that an <em>AIP</em> or <em>File</em> is corrupted and is not recoverable. The TDA
-                        decides to dispose of it.
-                    </span>
-                </cpp:stepDescription>
-                <cpp:output>
-                    <cpp:outputElement>
-                        <span>
-                            Storage management information (list of affected <em>AIPs</em>, <em>Files</em>)
-                        </span>
-                    </cpp:outputElement>
-                </cpp:output>
-                <cpp:output>
-                    <cpp:outputElement>
-                        <span>
-                            Disposal request
-                        </span>
-                    </cpp:outputElement>
-                </cpp:output>
-            </cpp:step>
-            <cpp:step stepNumber="1b">
-                <cpp:input>
-                    <cpp:inputElement>
-                        <span>
-                            Changes to the needs of the designated community
-                        </span>
-                    </cpp:inputElement>
-                    <cpp:supplier>CPP-018</cpp:supplier>
-                </cpp:input>
-                <cpp:stepDescription>
-                    <span>
-                        The designated community no longer has a need for the data, it is
-                        demonstrably not making any use of the data, and there is no expectation 
-                        that it will make any future use of the data. Therefore, the TDA decides to 
-                        dispose of the data.
-                    </span>
-                </cpp:stepDescription>
-                <cpp:output>
-                    <cpp:outputElement>
-                        <span>
-                            <em>Storage management information</em> (list of affected <em>AIPs</em>, <em>Files</em>)
-                        </span>
-                    </cpp:outputElement>
-                </cpp:output>
-                <cpp:output>
-                    <cpp:outputElement>
-                        <span>
-                            Disposal request
-                        </span>
-                    </cpp:outputElement>
-                </cpp:output>
-            </cpp:step>
-            <cpp:step stepNumber="1c">
-                <cpp:input>
-                    <cpp:inputElement>
-                        <span>
-                            Quality reports
-                        </span>
-                    </cpp:inputElement>
-                    <cpp:supplier>CPP-019</cpp:supplier>
-                </cpp:input>
-                <cpp:stepDescription>
-                    <span>
-                        The quality of the data no longer meets the minimum requirements of the 
-                        designated community or the data is available in an alternative and higher quality
-                        version or format. Therefore, the TDA decides to dispose of the data.
-                    </span>
-                </cpp:stepDescription>
-                <cpp:output>
-                    <cpp:outputElement>
-                        <span>
-                            <em>Storage management information</em> (list of affected <em>AIPs</em>, <em>Files</em>)
-                        </span>
-                    </cpp:outputElement>
-                </cpp:output>
-                <cpp:output>
-                    <cpp:outputElement>
-                        <span>
-                            Disposal request
-                        </span>
-                    </cpp:outputElement>
-                </cpp:output>
-            </cpp:step>
-            <cpp:step stepNumber="1d">
-                <cpp:input>
-                    <cpp:inputElement>
-                        <span>
-                            Quality reports
-                        </span>
-                    </cpp:inputElement>                    
-                </cpp:input>
-                <cpp:input>
-                    <cpp:inputElement>
-                        <span>
-                            Intellectual property change
-                        </span>
-                    </cpp:inputElement>                    
-                    <cpp:supplier>CPP-020</cpp:supplier>
-                </cpp:input>
-                <cpp:input>
-                    <cpp:inputElement>
-                        <span>
-                            Risk detection
-                        </span>
-                    </cpp:inputElement>                    
-                    <cpp:supplier>CPP-023</cpp:supplier>
-                </cpp:input>
-                <cpp:stepDescription>
-                    <span>
-                        TDA gets a trigger event indicating that an <em>AIP</em> or <em>File</em> needs 
-                        to be disposed of.
-                    </span>
-                </cpp:stepDescription>
-                <cpp:output>
-                    <cpp:outputElement>
-                        <span>
-                            <em>Storage management information</em> (list of affected <em>AIPs</em>, <em>Files</em>)
-                        </span>
-                    </cpp:outputElement>
-                </cpp:output>
-                <cpp:output>
-                    <cpp:outputElement>
-                        <span>
-                            Disposal request
-                        </span>
-                    </cpp:outputElement>
-                </cpp:output>
-            </cpp:step>
-            <cpp:step stepNumber="1e">
-                <cpp:input>
-                    <cpp:inputElement>
-                        <span>
-                            Appraisal reports 
-                        </span>
-                    </cpp:inputElement>
-                </cpp:input>
-                <cpp:stepDescription>
-                    <span>
-                        The retention period of the data has been fulfilled according to the
-                        appraisal or reappraisal of the data.
-                    </span>
-                </cpp:stepDescription>
-                <cpp:output>
-                    <cpp:outputElement>
-                        <span>
-                            <em>Storage management information</em> (list of affected <em>AIPs</em>, <em>Files</em>)
-                        </span>
-                    </cpp:outputElement>
-                </cpp:output>
-            </cpp:step>
-            </cpp:stepGroup>
+                    <cpp:step stepNumber="1a">
+                        <cpp:input>
+                            <cpp:inputElement>
+                                <span>
+                                    Quality reports 
+                                </span>
+                            </cpp:inputElement>
+                            <cpp:supplier>CPP-004</cpp:supplier>
+                            <cpp:supplier>CPP-027</cpp:supplier>
+                        </cpp:input>
+                        <cpp:stepDescription>
+                            <span>
+                                TDA finds out, from management events or other triggering events,
+                                that an <em>AIP</em> or <em>File</em> is corrupted and is not recoverable. The TDA
+                                decides to dispose of it.
+                            </span>
+                        </cpp:stepDescription>
+                        <cpp:output>
+                            <cpp:outputElement>
+                                <span>
+                                    Storage management information (list of affected <em>AIPs</em>, <em>Files</em>)
+                                </span>
+                            </cpp:outputElement>
+                        </cpp:output>
+                        <cpp:output>
+                            <cpp:outputElement>
+                                <span>
+                                    Disposal request
+                                </span>
+                            </cpp:outputElement>
+                        </cpp:output>
+                    </cpp:step>
+                    <cpp:step stepNumber="1b">
+                        <cpp:input>
+                            <cpp:inputElement>
+                                <span>
+                                    Changes to the needs of the designated community
+                                </span>
+                            </cpp:inputElement>
+                            <cpp:supplier>CPP-018</cpp:supplier>
+                        </cpp:input>
+                        <cpp:stepDescription>
+                            <span>
+                                The designated community no longer has a need for the data, it is
+                                demonstrably not making any use of the data, and there is no expectation 
+                                that it will make any future use of the data. Therefore, the TDA decides to 
+                                dispose of the data.
+                            </span>
+                        </cpp:stepDescription>
+                        <cpp:output>
+                            <cpp:outputElement>
+                                <span>
+                                    <em>Storage management information</em> (list of affected <em>AIPs</em>, <em>Files</em>)
+                                </span>
+                            </cpp:outputElement>
+                        </cpp:output>
+                        <cpp:output>
+                            <cpp:outputElement>
+                                <span>
+                                    Disposal request
+                                </span>
+                            </cpp:outputElement>
+                        </cpp:output>
+                    </cpp:step>
+                    <cpp:step stepNumber="1c">
+                        <cpp:input>
+                            <cpp:inputElement>
+                                <span>
+                                    Quality reports
+                                </span>
+                            </cpp:inputElement>
+                            <cpp:supplier>CPP-019</cpp:supplier>
+                        </cpp:input>
+                        <cpp:stepDescription>
+                            <span>
+                                The quality of the data no longer meets the minimum requirements of the 
+                                designated community or the data is available in an alternative and higher quality
+                                version or format. Therefore, the TDA decides to dispose of the data.
+                            </span>
+                        </cpp:stepDescription>
+                        <cpp:output>
+                            <cpp:outputElement>
+                                <span>
+                                    <em>Storage management information</em> (list of affected <em>AIPs</em>, <em>Files</em>)
+                                </span>
+                            </cpp:outputElement>
+                        </cpp:output>
+                        <cpp:output>
+                            <cpp:outputElement>
+                                <span>
+                                    Disposal request
+                                </span>
+                            </cpp:outputElement>
+                        </cpp:output>
+                    </cpp:step>
+                    <cpp:step stepNumber="1d">
+                        <cpp:input>
+                            <cpp:inputElement>
+                                <span>
+                                    Quality reports
+                                </span>
+                            </cpp:inputElement>                    
+                        </cpp:input>
+                        <cpp:input>
+                            <cpp:inputElement>
+                                <span>
+                                    Intellectual property change
+                                </span>
+                            </cpp:inputElement>                    
+                            <cpp:supplier>CPP-020</cpp:supplier>
+                        </cpp:input>
+                        <cpp:input>
+                            <cpp:inputElement>
+                                <span>
+                                    Risk detection
+                                </span>
+                            </cpp:inputElement>                    
+                            <cpp:supplier>CPP-023</cpp:supplier>
+                        </cpp:input>
+                        <cpp:stepDescription>
+                            <span>
+                                TDA gets a trigger event indicating that an <em>AIP</em> or <em>File</em> needs 
+                                to be disposed of.
+                            </span>
+                        </cpp:stepDescription>
+                        <cpp:output>
+                            <cpp:outputElement>
+                                <span>
+                                    <em>Storage management information</em> (list of affected <em>AIPs</em>, <em>Files</em>)
+                                </span>
+                            </cpp:outputElement>
+                        </cpp:output>
+                        <cpp:output>
+                            <cpp:outputElement>
+                                <span>
+                                    Disposal request
+                                </span>
+                            </cpp:outputElement>
+                        </cpp:output>
+                    </cpp:step>
+                    <cpp:step stepNumber="1e">
+                        <cpp:input>
+                            <cpp:inputElement>
+                                <span>
+                                    Appraisal reports 
+                                </span>
+                            </cpp:inputElement>
+                        </cpp:input>
+                        <cpp:stepDescription>
+                            <span>
+                                The retention period of the data has been fulfilled according to the
+                                appraisal or reappraisal of the data.
+                            </span>
+                        </cpp:stepDescription>
+                        <cpp:output>
+                            <cpp:outputElement>
+                                <span>
+                                    <em>Storage management information</em> (list of affected <em>AIPs</em>, <em>Files</em>)
+                                </span>
+                            </cpp:outputElement>
+                        </cpp:output>
+                    </cpp:step>
+                </cpp:stepGroup>
             <cpp:step stepNumber="2">
                 <cpp:input>
                     <cpp:inputElement>
@@ -603,8 +603,8 @@
                     </cpp:outputElement>
                 </cpp:output>
             </cpp:step>
-            </cpp:stepGroup>
-        </cpp:stepByStepDescription>
+        </cpp:stepGroup>
+    </cpp:stepByStepDescription>
     </cpp:process>
     <cpp:rationaleWorstCase>
         <cpp:purpose>

--- a/CPP-019/cpp-019.xml
+++ b/CPP-019/cpp-019.xml
@@ -213,7 +213,7 @@
                 </cpp:step>
                 <cpp:stepGroup type="alternative"
                     label="Different handling based on nature of quality properties">
-                    <cpp:step stepNumber="3">
+                    <cpp:step stepNumber="3a">
                         <cpp:input>
                             <cpp:inputElement>
                                 <span>Specification of the data required for the assessment</span>
@@ -247,7 +247,7 @@
                             </cpp:outputElement>
                         </cpp:output>
                     </cpp:step>
-                    <cpp:step stepNumber="4">
+                    <cpp:step stepNumber="3b">
                         <cpp:input>
                             <cpp:inputElement>
                                 <span>Specification of the data required for the assessment</span>
@@ -276,7 +276,7 @@
                             </cpp:outputElement>
                         </cpp:output>
                     </cpp:step>
-                    <cpp:step stepNumber="5">
+                    <cpp:step stepNumber="3c">
                         <cpp:input>
                             <cpp:inputElement>
                                 <span>Specification of the data required for the assessment</span>
@@ -315,7 +315,7 @@
                             </cpp:outputElement>
                         </cpp:output>
                     </cpp:step>
-                    <cpp:step stepNumber="6">
+                    <cpp:step stepNumber="3d">
                         <cpp:input>
                             <cpp:inputElement>
                                 <span>Specification of the data required for the assessment</span>
@@ -351,7 +351,7 @@
                             </cpp:outputElement>
                         </cpp:output>
                     </cpp:step>
-                    <cpp:step stepNumber="7">
+                    <cpp:step stepNumber="3e">
                         <cpp:input>
                             <cpp:inputElement>
                                 <span>Specification of the data required for the assessment</span>
@@ -375,7 +375,7 @@
                             </cpp:outputElement>
                         </cpp:output>
                     </cpp:step>
-                    <cpp:step stepNumber="8">
+                    <cpp:step stepNumber="3f">
                         <cpp:input>
                             <cpp:inputElement>
                                 <span>Specification of the data required for the assessment</span>
@@ -409,7 +409,7 @@
                         </cpp:output>
                     </cpp:step>
                 </cpp:stepGroup>
-                <cpp:step stepNumber="9">
+                <cpp:step stepNumber="4">
                     <cpp:input>
                         <cpp:inputElement optional="true">
                             <span>File format identifier</span>
@@ -449,7 +449,7 @@
                         </cpp:outputElement>
                     </cpp:output>
                 </cpp:step>
-                <cpp:step stepNumber="10">
+                <cpp:step stepNumber="5">
                     <cpp:input>
                         <cpp:inputElement>
                             <span>Quality assessment report</span>
@@ -466,7 +466,7 @@
                         <cpp:customer>CPP-029</cpp:customer>
                     </cpp:output>
                 </cpp:step>
-                <cpp:step stepNumber="11" optional="true">
+                <cpp:step stepNumber="6" optional="true">
                     <cpp:stepDescription>
                         <span> Optional: The quality of an <em>Object</em>, <em>AIP</em> or <em>
                             Metadata</em> can be enhanced or modified based on the quality

--- a/CPP-025/cpp-025.xml
+++ b/CPP-025/cpp-025.xml
@@ -191,23 +191,23 @@
             </cpp:outputElement>
           </cpp:output>
         </cpp:step>
-        <cpp:step stepNumber="5a">
-          <cpp:input>
-            <cpp:inputElement>
-              <span>Authenticated and authorised request</span>
-            </cpp:inputElement>
-          </cpp:input>
-          <cpp:stepDescription>
-            <span>The TDA locates the <em>AIP</em> or set of <em>AIPs</em>, from which the <em>DIP</em>
-              is created</span>
-          </cpp:stepDescription>
-          <cpp:output>
-            <cpp:outputElement>
-              <span><em>AIP</em> or a set of <em>AIPs</em></span>
-            </cpp:outputElement>
-          </cpp:output>
-        </cpp:step>
-        <cpp:stepGroup type="alternative">
+        <cpp:stepGroup type="alternative" label="Authentication and authorisation of the DIP request">
+          <cpp:step stepNumber="5a">
+            <cpp:input>
+              <cpp:inputElement>
+                <span>Authenticated and authorised request</span>
+              </cpp:inputElement>
+            </cpp:input>
+            <cpp:stepDescription>
+              <span>The TDA locates the <em>AIP</em> or set of <em>AIPs</em>, from which the <em>DIP</em>
+                is created</span>
+            </cpp:stepDescription>
+            <cpp:output>
+              <cpp:outputElement>
+                <span><em>AIP</em> or a set of <em>AIPs</em></span>
+              </cpp:outputElement>
+            </cpp:output>
+          </cpp:step>
           <cpp:step stepNumber="5b">
             <cpp:input>
               <cpp:inputElement>
@@ -224,7 +224,7 @@
             </cpp:output>
           </cpp:step>
         </cpp:stepGroup>
-        <cpp:step stepNumber="6a">
+        <cpp:step stepNumber="6">
           <cpp:input>
             <cpp:inputElement>
               <span><em>AIP</em> or a set of <em>AIPs</em></span>
@@ -240,7 +240,7 @@
             </cpp:outputElement>
           </cpp:output>
         </cpp:step>
-        <cpp:step stepNumber="6b">
+        <cpp:step stepNumber="7">
           <cpp:input>
             <cpp:inputElement>
               <span><em>AIP</em> or a set of <em>AIPs</em></span>
@@ -257,7 +257,7 @@
             </cpp:outputElement>
           </cpp:output>
         </cpp:step>
-        <cpp:step stepNumber="6c">
+        <cpp:step stepNumber="8">
           <cpp:input>
             <cpp:inputElement>
               <span><em>AIP</em> or a set of <em>AIPs</em></span>
@@ -275,7 +275,7 @@
             </cpp:outputElement>
           </cpp:output>
         </cpp:step>
-        <cpp:step stepNumber="6d">
+        <cpp:step stepNumber="9">
           <cpp:input>
             <cpp:inputElement>
               <span>
@@ -295,7 +295,7 @@
             </cpp:outputElement>
           </cpp:output>
         </cpp:step>
-        <cpp:step stepNumber="7">
+        <cpp:step stepNumber="10">
           <cpp:input>
             <cpp:inputElement>
               <span>


### PR DESCRIPTION
CPP-017: stepGrouping seemed just like it should. Only changes to indentation.

CPP-019: just fixed numbering a bit to be inline with other in terms of numbering within stepGroup

CPP-025: changed the stepGroup to cover just the authentication and authorisation, as these steps may produce different outcomes. And then let the remaining numbering be just incremental, because they follow the sequence.