### PR TITLE
Update actions

### DIFF
--- a/.github/workflows/generate-html.yml
+++ b/.github/workflows/generate-html.yml
@@ -28,7 +28,7 @@ jobs:
           private-key: ${{ secrets.ACTION_BOT_PRIVATE_KEY }}
           
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/generate-markdown.yml
+++ b/.github/workflows/generate-markdown.yml
@@ -26,7 +26,7 @@ jobs:
           private-key: ${{ secrets.ACTION_BOT_PRIVATE_KEY }}
           
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -13,7 +13,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
             
             - name: Install xmllint (libxml2-utils)
               run: sudo apt-get update && sudo apt-get install -y libxml2-utils


### PR DESCRIPTION
Upgrade the GitHub Actions checkout action from v4 to v5 in preparation for the deprecation of node v20.